### PR TITLE
Fixed tap handling for controller with swipes when accessibility VoiceOver is turned on

### DIFF
--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -345,10 +345,6 @@ class SwipeController: NSObject {
 extension SwipeController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if gestureRecognizer == tapGestureRecognizer {
-            if UIAccessibility.isVoiceOverRunning {
-                scrollView?.hideSwipeables()
-            }
-            
             let swipedCell = scrollView?.swipeables.first(where: {
                 $0.state.isActive ||
                     $0.panGestureRecognizer.state == .began ||


### PR DESCRIPTION
We are in this if block when accessibility is on and there are some swipes on controller (e.g. Cells inside collection view). And this code makes it impossible for collection view to handle tap action.